### PR TITLE
Trust no proxy to deliver the correct ClientIp

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -35,6 +35,11 @@ func Run(config *ServerConfig, pool *pgxpool.Pool) error {
 
 	app := gin.Default()
 
+	err = app.SetTrustedProxies(nil)
+	if err != nil {
+		return err
+	}
+
 	app.Use(cors)
 
 	app.Use(sentrygin.New(sentrygin.Options{}))


### PR DESCRIPTION
As we do not rely on the client's ip, we can elimiate the following warning:
[GIN-debug] [WARNING] You trusted all proxies, this is NOT safe. We recommend you to set a value.
Please check https://pkg.go.dev/github.com/gin-gonic/gin#readme-don-t-trust-all-proxies for details.